### PR TITLE
send latency to airtable based on conversationID

### DIFF
--- a/vocode/streaming/agent/base_agent.py
+++ b/vocode/streaming/agent/base_agent.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import traceback
 import asyncio
 from enum import Enum
 import json
@@ -220,7 +221,7 @@ class RespondAgent(BaseAgent[AgentConfigType]):
                     conversation_id=conversation_id,
                 )
         except Exception as e:
-            self.logger.error(f"Error while generating response: {e}", exc_info=True)
+            self.logger.error(f"Error {e}, Trace: {traceback.format_exc()}")
             response = None
             return True
         if response:
@@ -292,6 +293,8 @@ class RespondAgent(BaseAgent[AgentConfigType]):
                     self.logger.debug("Goodbye detection timed out")
         except asyncio.CancelledError:
             pass
+        except Exception as e:
+            self.logger.error(f"Error {e}, Trace: {traceback.format_exc()}")
 
     def call_function(self, function_call: FunctionCall, agent_input: AgentInput):
         action = self.action_factory.create_action(function_call.name)

--- a/vocode/streaming/telephony/server/router/calls.py
+++ b/vocode/streaming/telephony/server/router/calls.py
@@ -21,6 +21,7 @@ from vocode.streaming.utils.base_router import BaseRouter
 from vocode.streaming.utils.events_manager import EventsManager
 
 from opentelemetry import trace
+import traceback
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
@@ -115,20 +116,21 @@ class CallsRouter(BaseRouter):
             call_config = await self.config_manager.get_config(id)
             if not call_config:
                 raise HTTPException(status_code=400, detail="No active phone call")
-
-            call = self._from_call_config(
-                base_url=self.base_url,
-                call_config=call_config,
-                config_manager=self.config_manager,
-                conversation_id=id,
-                transcriber_factory=self.transcriber_factory,
-                agent_factory=self.agent_factory,
-                synthesizer_factory=self.synthesizer_factory,
-                events_manager=self.events_manager,
-                logger=self.logger,
-            )
-
-            await call.attach_ws_and_start(websocket)
+            try:
+                call = self._from_call_config(
+                    base_url=self.base_url,
+                    call_config=call_config,
+                    config_manager=self.config_manager,
+                    conversation_id=id,
+                    transcriber_factory=self.transcriber_factory,
+                    agent_factory=self.agent_factory,
+                    synthesizer_factory=self.synthesizer_factory,
+                    events_manager=self.events_manager,
+                    logger=self.logger,
+                )
+                await call.attach_ws_and_start(websocket)
+            except Exception as e:
+                self.logger.error(f"Error {e}, Trace: {traceback.format_exc()}")
             self.logger.debug("Phone WS connection closed for chat {}".format(id))
         child_spans = span_exporter.get_finished_spans()
         await database_exporter.export(child_spans)

--- a/vocode/streaming/telephony/server/utils.py
+++ b/vocode/streaming/telephony/server/utils.py
@@ -1,0 +1,70 @@
+import logging
+from opentelemetry import trace
+import os
+import aiohttp
+import json
+
+
+class SpanLogHandler(logging.Handler):
+    def emit(self, record):
+        self.format(record)
+        tracer = trace.get_tracer(__name__)
+        with tracer.start_as_current_span(
+            name="log_span",
+        ) as span:
+            span.set_attribute("message", record.message)
+
+
+class DatabaseExporter:
+    def __init__(self, conversation_id):
+        self.conversation_id = conversation_id
+        self.base_url = (
+            f"https://api.airtable.com/v0/{os.getenv('AIRTABLE_BASE_ID')}/logs"
+        )
+        self.headers = {
+            "Authorization": f"Bearer {os.getenv('AIRTABLE_ACCESS_TOKEN')}",
+            "Content-Type": "application/json",
+        }
+
+    async def export(self, spans):
+        async with aiohttp.ClientSession() as session:
+            record_id = await self.get_record_id(session)
+            record_data = {"conversation_id": self.conversation_id, "log": []}
+            for span in spans:
+                if span.name == "log_span":
+                    record_data["log"].append({"message": span.attributes["message"]})
+                else:
+                    record_data["log"].append(
+                        {
+                            "name": span.name,
+                            "duration": (span.end_time - span.start_time) / 1e9,
+                        }
+                    )
+            record_data["log"] = json.dumps(record_data["log"], indent=4)
+            payload = {"records": [{"id": record_id, "fields": record_data}]}
+            async with session.patch(
+                self.base_url, headers=self.headers, json=payload
+            ) as response:
+                if response.status == 200:
+                    print("Successfully logged to the database")
+                else:
+                    print(
+                        "Failed to log to the database",
+                        response.status,
+                        await response.text(),
+                    )
+
+    async def get_record_id(self, session):
+        params = {
+            "filterByFormula": f"{{conversation_id}} = '{self.conversation_id}'",
+            "maxRecords": 1,
+        }
+        async with session.get(
+            self.base_url, headers=self.headers, params=params
+        ) as response:
+            if response.status == 200:
+                data = await response.json()
+                records = data.get("records", [])
+                if records:
+                    return records[0].get("id")
+        return None

--- a/vocode/streaming/telephony/server/utils.py
+++ b/vocode/streaming/telephony/server/utils.py
@@ -13,7 +13,7 @@ class SpanLogHandler(logging.Handler):
             name="log_span",
         ) as span:
             span.set_attribute("message", record.message)
-
+            span.set_attribute("level", record.levelname)
 
 class DatabaseExporter:
     def __init__(self, conversation_id):
@@ -28,43 +28,23 @@ class DatabaseExporter:
 
     async def export(self, spans):
         async with aiohttp.ClientSession() as session:
-            record_id = await self.get_record_id(session)
             record_data = {"conversation_id": self.conversation_id, "log": []}
             for span in spans:
                 if span.name == "log_span":
-                    record_data["log"].append({"message": span.attributes["message"]})
+                    if span.attributes["level"] == "ERROR":
+                        # Can send logs to Slack from here
+                        record_data["log"].append({"ERROR": span.attributes["message"]})
+                    else:
+                        record_data["log"].append({"message": span.attributes["message"]})
                 else:
-                    record_data["log"].append(
-                        {
-                            "name": span.name,
-                            "duration": (span.end_time - span.start_time) / 1e9,
-                        }
-                    )
+                    record_data["log"].append({
+                        "name": span.name,
+                        "duration": (span.end_time - span.start_time) / 1e9,
+                    })
             record_data["log"] = json.dumps(record_data["log"], indent=4)
-            payload = {"records": [{"id": record_id, "fields": record_data}]}
-            async with session.patch(
-                self.base_url, headers=self.headers, json=payload
-            ) as response:
+            payload = {"performUpsert": {"fieldsToMergeOn": ["conversation_id"]}, "records": [{"fields": record_data}]}
+            async with session.patch(self.base_url, headers=self.headers, json=payload) as response:
                 if response.status == 200:
                     print("Successfully logged to the database")
                 else:
-                    print(
-                        "Failed to log to the database",
-                        response.status,
-                        await response.text(),
-                    )
-
-    async def get_record_id(self, session):
-        params = {
-            "filterByFormula": f"{{conversation_id}} = '{self.conversation_id}'",
-            "maxRecords": 1,
-        }
-        async with session.get(
-            self.base_url, headers=self.headers, params=params
-        ) as response:
-            if response.status == 200:
-                data = await response.json()
-                records = data.get("records", [])
-                if records:
-                    return records[0].get("id")
-        return None
+                    print("Failed to log to the database", response.status, await response.text())

--- a/vocode/streaming/transcriber/deepgram_transcriber.py
+++ b/vocode/streaming/transcriber/deepgram_transcriber.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import traceback
 import logging
 from typing import Optional
 import websockets
@@ -179,7 +180,8 @@ class DeepgramTranscriber(BaseAsyncTranscriber[DeepgramTranscriberConfig]):
                 while not self._ended:
                     try:
                         data = await asyncio.wait_for(self.input_queue.get(), 5)
-                    except asyncio.exceptions.TimeoutError:
+                    except asyncio.exceptions.TimeoutError as e:
+                        self.logger.error(f"Got error {e} in Deepgram receiver {e}, Trace: {traceback.format_exc()}")
                         break
                     num_channels = 1
                     sample_width = 2
@@ -199,7 +201,7 @@ class DeepgramTranscriber(BaseAsyncTranscriber[DeepgramTranscriberConfig]):
                     try:
                         msg = await ws.recv()
                     except Exception as e:
-                        self.logger.debug(f"Got error {e} in Deepgram receiver")
+                        self.logger.error(f"Got error {e} in Deepgram receiver {e}, Trace: {traceback.format_exc()}")
                         break
                     data = json.loads(msg)
                     if (


### PR DESCRIPTION
Created a databaseexporter, to collate all child spans (agent/synth latencies) under this trace (which is the conversation trace, and has the conversationID),

sends the latency data and span name to airtable 'logs' table, once the conversation ends

table can be seen here - https://airtable.com/appiQmhezOhxW1TJb/tblNnZguGqsCmdI7S/viwoPcUayt6HqFtKA?blocks=hide